### PR TITLE
Precise Java version requirement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This application show how to configure a maven project to integrate Spoonware.  
 - Diagnostic all your bugs with the provided informations.
 - Fix your bugs at runtime, without recompiling and re-deploing your application.
 
-## usage
+## Usage
 
 First, you should create a Spoonware account : https://spoonware.lille.inria.fr/invitation.html
 
@@ -14,7 +14,9 @@ When you are successfully logged, you could create an application. You get an ID
 
 ## Start application and monitor
 
-You could start the example application with :
+This example application works under **Java version 1.8**
+
+You can start the example application with :
 $ mvn -P spoonware clean compile exec:java
 
 The application start and you collect bugs in your dashboard.


### PR DESCRIPTION
Due to the dependency to the [Executable] (http://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Executable.html) Java class, the project needs to be compiled under the Java 1.8 version.

This fix add the requirement into the README file.